### PR TITLE
GP-1640: Add CiviBanking account reference types

### DIFF
--- a/pspsepa.php
+++ b/pspsepa.php
@@ -72,6 +72,7 @@ function pspsepa_civicrm_enable() {
 
   $customData = new CRM_Pspsepa_CustomData('de.systopia.pspsepa');
   $customData->syncOptionGroup(__DIR__ . '/resources/formats_option_group.json');
+  $customData->syncOptionGroup(__DIR__ . '/resources/banking_reference_types_option_group.json');
 }
 
 /**

--- a/resources/banking_reference_types_option_group.json
+++ b/resources/banking_reference_types_option_group.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Register PSP bank account reference types",
+  "_lookup": ["name"],
+  "_translate": ["title"],
+  "name": "civicrm_banking.reference_types",
+  "title": "CiviBanking bank account reference types",
+  "is_active": "1",
+  "_values": [
+    {
+      "_lookup": ["name"],
+      "_translate": ["label"],
+      "label": "PayU",
+      "description": "PayU Card Token",
+      "name": "NBAN_PAYU",
+      "value": "NBAN_PAYU",
+      "filter": "0",
+      "is_reserved": "0",
+      "is_active": "1"
+    },
+    {
+      "_lookup": ["name"],
+      "_translate": ["label"],
+      "label": "Adyen",
+      "description": "Adyen Shopper Reference",
+      "name": "NBAN_ADYEN",
+      "value": "NBAN_ADYEN",
+      "filter": "0",
+      "is_reserved": "0",
+      "is_active": "1"
+    }
+  ]
+}


### PR DESCRIPTION
This adds dedicated account reference types for each PSP, making it easier to distinguish them in the UI and backend.