### PR TITLE
GP-1640: Don't require contact to have email for Adyen export

### DIFF
--- a/templates/Sepa/Formats/adyen/Format.php
+++ b/templates/Sepa/Formats/adyen/Format.php
@@ -83,15 +83,15 @@ class CRM_Sepa_Logic_Format_adyen extends CRM_Sepa_Logic_Format {
    * @throws Exception
    */
   protected function getShopperEmailFromContact($contact_id) {
-    $email = civicrm_api3('Email', 'getsingle', array(
+    $email = civicrm_api3('Email', 'get', array(
       'contact_id'     => $contact_id,
       'is_primary' => 1,
       'return' => 'email',
     ));
-    if (empty($email['email'])) {
-      throw new Exception(E::ts('Contact does not have a primary e-mail address.'));
+    if ($email['count'] > 0) {
+      return reset($email['values'])['email'];
     }
-    return $email['email'];
+    return NULL;
   }
 
   /**


### PR DESCRIPTION
Prior to this, the Adyen export formatter would simply skip the post-processing of contributions from contacts without a primary email, so fields like `shopperReference` would not be set.