### PR TITLE
GP-8547 Add submitOnce to runner form button

### DIFF
--- a/CRM/Pspsepa/Form/PspRunnerForm.php
+++ b/CRM/Pspsepa/Form/PspRunnerForm.php
@@ -102,13 +102,14 @@ class CRM_Pspsepa_Form_PspRunnerForm extends CRM_Core_Form {
       'utf8File'
     );
 
-    $this->addButtons(array(
-      array(
+    $this->addButtons([
+      [
         'type' => 'submit',
         'name' => E::ts('Submit'),
         'isDefault' => TRUE,
-      ),
-    ));
+        'submitOnce' => TRUE,
+      ],
+    ]);
 
     // Export form elements.
     $this->assign('elementNames', $this->getRenderableElementNames());


### PR DESCRIPTION
Add `submitOnce` in order to prevent (one reason for) double-submissions.